### PR TITLE
[MAJOR] EDA-602 Add default permission to users at registration

### DIFF
--- a/supplier_management_site/settings/base.py
+++ b/supplier_management_site/settings/base.py
@@ -49,6 +49,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.user.get_username',
     'social_core.pipeline.mail.mail_validation',
     'social_core.pipeline.user.create_user',
+    'users_app.pipeline.pipeline.add_user_to_group',
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
     'social_core.pipeline.user.user_details',

--- a/users_app/factory_boy.py
+++ b/users_app/factory_boy.py
@@ -1,7 +1,5 @@
 import factory
 
-from django.contrib.auth.models import Group
-
 from users_app.models import (
     User
 )

--- a/users_app/factory_boy.py
+++ b/users_app/factory_boy.py
@@ -1,4 +1,7 @@
 import factory
+
+from django.contrib.auth.models import Group
+
 from users_app.models import (
     User
 )

--- a/users_app/pipeline/pipeline.py
+++ b/users_app/pipeline/pipeline.py
@@ -4,18 +4,19 @@ from users_app import ALLOWED_AP_ACCOUNTS
 
 
 def add_user_to_group(is_new, user, *args, **kwargs):
-    if is_new and user.email in ALLOWED_AP_ACCOUNTS:
-        ap_admin_group = Group.objects.get(name='ap_admin')
-        ap_manager_group = Group.objects.get(name='ap_manager')
-        user.groups.add(ap_admin_group, ap_manager_group)
+    if is_new:
+        if user.email in ALLOWED_AP_ACCOUNTS:
+            ap_admin_group = Group.objects.get(name='ap_admin')
+            ap_manager_group = Group.objects.get(name='ap_manager')
+            user.groups.add(ap_admin_group, ap_manager_group)
 
-    elif is_new and user.email.endswith('@eventbrite.com'):
-        ap_reporter_group = Group.objects.get(name='ap_reporter')
-        user.groups.add(ap_reporter_group)
+        elif user.email.endswith('@eventbrite.com'):
+            ap_reporter_group = Group.objects.get(name='ap_reporter')
+            user.groups.add(ap_reporter_group)
 
-    elif is_new:
-        supplier_group = Group.objects.get(name='supplier')
-        user.groups.add(supplier_group)
+        else:
+            supplier_group = Group.objects.get(name='supplier')
+            user.groups.add(supplier_group)
 
     return {
             'is_new': is_new,

--- a/users_app/pipeline/pipeline.py
+++ b/users_app/pipeline/pipeline.py
@@ -1,0 +1,23 @@
+from django.contrib.auth.models import Group
+
+from users_app import ALLOWED_AP_ACCOUNTS
+
+
+def add_user_to_group(is_new, user, *args, **kwargs):
+    if is_new and user.email in ALLOWED_AP_ACCOUNTS:
+        ap_admin_group = Group.objects.get(name='ap_admin')
+        ap_manager_group = Group.objects.get(name='ap_manager')
+        user.groups.add(ap_admin_group, ap_manager_group)
+
+    elif is_new and user.email.endswith('@eventbrite.com'):
+        ap_reporter_group = Group.objects.get(name='ap_reporter')
+        user.groups.add(ap_reporter_group)
+
+    elif is_new:
+        supplier_group = Group.objects.get(name='supplier')
+        user.groups.add(supplier_group)
+
+    return {
+            'is_new': is_new,
+            'user': user
+        }

--- a/users_app/tests/test_permissions.py
+++ b/users_app/tests/test_permissions.py
@@ -1,8 +1,11 @@
 from django.test import TestCase
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-
+from users_app.factory_boy import (
+    UserFactory,
+)
 from utils.permissions import create_groups_and_apply_permisssions
+from users_app.pipeline.pipeline import add_user_to_group
 
 
 class TestUser(TestCase):
@@ -26,3 +29,30 @@ class TestUser(TestCase):
 
         for group in groups.keys():
             self.assertTrue(Group.objects.filter(name=group).exists())
+
+
+class TestUserPermissionGroup(TestCase):
+    def setUp(self):
+        self.ap_admin_group = Group.objects.get(name='ap_admin')
+        self.ap_manager_group = Group.objects.get(name='ap_manager')
+        self.ap_reporter_group = Group.objects.get(name='ap_reporter')
+        self.supplier_group = Group.objects.get(name='supplier')
+
+    def test_add_new_AP_to_admin_and_ap_manager_group(self):
+        user = UserFactory(email='nahuel.valencia@eventbrite.com')
+        add_user_to_group(True, user)
+
+        self.assertTrue(self.ap_admin_group in user.groups.all())
+        self.assertTrue(self.ap_manager_group in user.groups.all())
+
+    def test_add_new_AP_to_ap_reporter_group(self):
+        user = UserFactory(email='ap_no_in_the_list@eventbrite.com')
+        add_user_to_group(True, user)
+
+        self.assertTrue(self.ap_reporter_group in user.groups.all())
+
+    def test_add_new_SUPPLIER_to_a_supplier_group(self):
+        user = UserFactory(email='nahuel.valencia21@gmail.com')
+        add_user_to_group(True, user)
+
+        self.assertTrue(self.supplier_group in user.groups.all())

--- a/users_app/tests/test_permissions.py
+++ b/users_app/tests/test_permissions.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from django.test import TestCase
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
@@ -42,8 +44,19 @@ class TestUserPermissionGroup(TestCase):
         user = UserFactory(email='nahuel.valencia@eventbrite.com')
         add_user_to_group(True, user)
 
-        self.assertTrue(self.ap_admin_group in user.groups.all())
-        self.assertTrue(self.ap_manager_group in user.groups.all())
+        self.assertTrue((self.ap_admin_group and self.ap_manager_group) in user.groups.all())
+
+        self.assertFalse(self.supplier_group in user.groups.all())
+        self.assertFalse(self.ap_reporter_group in user.groups.all())
+
+    def test_AP_already_in_ap_admin_and_ap_manager_group_are_not_re_assigned(self):
+        user = UserFactory(email='nahuel.valencia@eventbrite.com')
+        user.groups.add(self.ap_admin_group, self.ap_manager_group)
+
+        add_user_to_group(False, user)
+
+        self.assertTrue((self.ap_admin_group and self.ap_manager_group) in user.groups.all())
+        self.assertTrue((self.supplier_group and self.ap_reporter_group) not in user.groups.all())
 
     def test_add_new_AP_to_ap_reporter_group(self):
         user = UserFactory(email='ap_no_in_the_list@eventbrite.com')
@@ -51,8 +64,32 @@ class TestUserPermissionGroup(TestCase):
 
         self.assertTrue(self.ap_reporter_group in user.groups.all())
 
+        self.assertFalse(self.ap_admin_group in user.groups.all())
+        self.assertFalse(self.ap_manager_group in user.groups.all())
+        self.assertFalse(self.supplier_group in user.groups.all())
+
+    def test_AP_already_in_ap_reporter_group_are_not_re_assigned(self):
+        user = UserFactory(email='ap_no_in_the_list@eventbrite.com')
+        user.groups.add(self.ap_reporter_group)
+
+        add_user_to_group(False, user)
+
+        self.assertEqual(self.ap_reporter_group, user.groups.get())
+
     def test_add_new_SUPPLIER_to_a_supplier_group(self):
         user = UserFactory(email='nahuel.valencia21@gmail.com')
         add_user_to_group(True, user)
 
         self.assertTrue(self.supplier_group in user.groups.all())
+
+        self.assertFalse(self.ap_admin_group in user.groups.all())
+        self.assertFalse(self.ap_manager_group in user.groups.all())
+        self.assertFalse(self.ap_reporter_group in user.groups.all())
+
+    def test_SUPPLIER_already_in_a_supplier_group_are_not_re_assigned(self):
+        user = UserFactory(email='nahuel.valencia21@gmail.com')
+        user.groups.add(self.supplier_group)
+
+        add_user_to_group(False, user)
+
+        self.assertEqual(self.supplier_group, user.groups.get())

--- a/users_app/tests/test_user.py
+++ b/users_app/tests/test_user.py
@@ -12,7 +12,9 @@ from supplier_app.tests.factory_boy import (
     CompanyFactory,
     CompanyUserPermissionFactory
 )
-from users_app.factory_boy import UserFactory
+from users_app.factory_boy import (
+    UserFactory,
+)
 
 SUPPLIER_HOME = '/suppliersite/supplier'
 AP_HOME = reverse('ap-taxpayers')


### PR DESCRIPTION
-When a new supplier sign in, he gets the suppliers default permissions.
-If an AP Manager (who is in a list of allowed APs) sign in, he gets defaults permissions, also he gets permissions to manage others ap permissions. In addition, if a different AP sign in, he gets reporter permissions.