### PR TITLE
[PATCH EDA-602] Tests refactored. Strategy to add users to permission

### DIFF
--- a/users_app/pipeline/pipeline.py
+++ b/users_app/pipeline/pipeline.py
@@ -1,24 +1,56 @@
+from abc import abstractmethod
+
 from django.contrib.auth.models import Group
 
 from users_app import ALLOWED_AP_ACCOUNTS
 
 
+def get_ap_allowed_accounts():
+    return ALLOWED_AP_ACCOUNTS
+
+
 def add_user_to_group(is_new, user, *args, **kwargs):
     if is_new:
-        if user.email in ALLOWED_AP_ACCOUNTS:
-            ap_admin_group = Group.objects.get(name='ap_admin')
-            ap_manager_group = Group.objects.get(name='ap_manager')
-            user.groups.add(ap_admin_group, ap_manager_group)
-
-        elif user.email.endswith('@eventbrite.com'):
-            ap_reporter_group = Group.objects.get(name='ap_reporter')
-            user.groups.add(ap_reporter_group)
-
-        else:
-            supplier_group = Group.objects.get(name='supplier')
-            user.groups.add(supplier_group)
+        strategy = get_strategy(user.email)
+        strategy.add_user_to_group(user)
 
     return {
             'is_new': is_new,
             'user': user
         }
+
+
+def get_strategy(email):
+    if email in get_ap_allowed_accounts():
+        return StrategyAdminManagerGroup()
+
+    elif email.endswith('@eventbrite.com'):
+        return StrategyReporterGroup()
+
+    else:
+        return StrategySupplierGroup()
+
+
+class StrategyUsersGroup():
+    @abstractmethod
+    def add_user_to_group(self, user):
+        pass
+
+
+class StrategySupplierGroup(StrategyUsersGroup):
+    def add_user_to_group(self, user):
+        supplier_group = Group.objects.get(name='supplier')
+        user.groups.add(supplier_group)
+
+
+class StrategyAdminManagerGroup(StrategyUsersGroup):
+    def add_user_to_group(self, user):
+        ap_admin_group = Group.objects.get(name='ap_admin')
+        ap_manager_group = Group.objects.get(name='ap_manager')
+        user.groups.add(ap_admin_group, ap_manager_group)
+
+
+class StrategyReporterGroup(StrategyUsersGroup):
+    def add_user_to_group(self, user):
+        ap_reporter_group = Group.objects.get(name='ap_reporter')
+        user.groups.add(ap_reporter_group)

--- a/users_app/tests/__init__.py
+++ b/users_app/tests/__init__.py
@@ -1,0 +1,3 @@
+ALLOWED_AP_ACCOUNTS_FOR_TEST = [
+    'nahuel.valencia@eventbrite.com',
+]

--- a/users_app/tests/test_permissions.py
+++ b/users_app/tests/test_permissions.py
@@ -1,5 +1,3 @@
-from parameterized import parameterized
-
 from django.test import TestCase
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType

--- a/users_app/tests/test_permissions.py
+++ b/users_app/tests/test_permissions.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from django.test import TestCase
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
Things to fix after code review:
- Use strategy patter to assign a user to a group
- Refactor test's names
- Create a helper function to assert in test
- Patch the list of ap_allowed_accounts