### PR TITLE
EDA-1175 Added a filter for emails during invitation

### DIFF
--- a/supplier_app/tests/test_view.py
+++ b/supplier_app/tests/test_view.py
@@ -1756,7 +1756,6 @@ class TestCompanyCreateView(TestCase):
 
     def test_valid_company_creation(self):
         self.client.force_login(self.ap_user)
-        # import ipdb; ipdb.set_trace()
         self._make_post()
         self.assertEqual(
             Company.objects.last().name,

--- a/supplier_app/tests/test_view.py
+++ b/supplier_app/tests/test_view.py
@@ -1707,7 +1707,7 @@ class TestCompanyCreateView(TestCase):
             'eb_entity':'1',
             'description':
                 'Bringing the world together through live experiences',
-            'email': 'buyer@eventbrite.com',
+            'email': 'supplier@gmail.com',
             'language': 'en',
         }
         self.client = Client()
@@ -1756,6 +1756,7 @@ class TestCompanyCreateView(TestCase):
 
     def test_valid_company_creation(self):
         self.client.force_login(self.ap_user)
+        # import ipdb; ipdb.set_trace()
         self._make_post()
         self.assertEqual(
             Company.objects.last().name,

--- a/supplier_app/views.py
+++ b/supplier_app/views.py
@@ -110,7 +110,8 @@ class CompanyCreatorView(UserLoginPermissionRequiredMixin, CreateView):
         return context
 
     def form_valid(self, form):
-        if Company.objects.filter(name=form.data['name']).exists():
+        lowercase_company_names = [name[0].lower() for name in Company.objects.values_list('name')]
+        if form.data['name'].lower() in lowercase_company_names or User.objects.filter(email=self.request.POST['email']):
             return HttpResponseRedirect(self.get_failure_url())
         company = self.save_company(form)
         InvitingBuyer.objects.create(company=company, inviting_buyer=self.request.user)


### PR DESCRIPTION
Buyers shouldn't be able to invite companies with emails already in use.

Also improved the company name filter to not be case sensitive.